### PR TITLE
Add libusb and dfu-util to ONL

### DIFF
--- a/builds/any/rootfs/jessie/common/all-base-packages.yml
+++ b/builds/any/rootfs/jessie/common/all-base-packages.yml
@@ -81,3 +81,5 @@
 - sysstat
 - ipmitool
 - lm-sensors
+- libusb-1.0-0-dev
+- dfu-util


### PR DESCRIPTION
That last commit only added it to the builder container.
This actually adds the packages to ONL.