### PR TITLE
Fix error in boot sequence

### DIFF
--- a/packages/base/all/vendor-config-onl/src/python/onl/install/InstallUtils.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/install/InstallUtils.py
@@ -354,8 +354,7 @@ class BlkidEntry:
     def splitDev(self):
         dev, part = self.device, ""
         
-        if "mmcblk" in dev:
-            print(dev)
+        if "p" in dev:
             dev, part = dev.split("p")
             part = "p" + part
             return dev, part

--- a/packages/base/all/vendor-config-onl/src/python/onl/install/InstallUtils.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/install/InstallUtils.py
@@ -354,10 +354,12 @@ class BlkidEntry:
     def splitDev(self):
         dev, part = self.device, ""
         
-        if "p" in dev:
-            dev, part = dev.split("p")
-            part = "p" + part
-            return dev, part
+        if "mmcblk" in dev:
+            if "p" in dev:
+                dev, part = dev.split("p")
+                part = "p" + part
+                return dev, part
+            return dev, ""
         else:
             while dev[-1:] in string.digits:
                 dev, part = dev[:-1], dev[-1] + part


### PR DESCRIPTION
This PR fixes the potential problem when we tried to split the name of a mmcblk storage device that didn't have a partition. Now, if any storage device has a partition, we split the name into the device name and the partition number. 